### PR TITLE
Make the plugin not blur guilds bar by default

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -17,10 +17,6 @@
 		pointer-events: none;
 	}
 
-	:not(.undarken).guilds-1SWlCJ {
-		filter: blur(10px);
-	}
-
 	.channel-stretched > nav > div > div > a {
 		max-width: none;
 	}


### PR DESCRIPTION
I'm not entirely sure why it was needed to blur the guilds bar in the first place but yeah it would be better not to do this by default.

Also great plugin. I wanted to do this for a long time but I lacked the knowledge and the motivation to do so.